### PR TITLE
Instead of just casting all JSON Numbers as Longs, include support for Doubles too

### DIFF
--- a/jsonized/src/main/java/de/itemis/jsonized/AbstractJsonized.xtend
+++ b/jsonized/src/main/java/de/itemis/jsonized/AbstractJsonized.xtend
@@ -24,7 +24,12 @@ abstract class AbstractJsonized {
                 if (element.boolean)
                     element.asBoolean
                 else if (element.isNumber)
-                    element.asNumber.longValue
+                    try {
+                        Long.parseLong(element.asString)
+                        element.asNumber.longValue as Long
+                    } catch(NumberFormatException e) {
+                        element.asNumber.doubleValue as Double
+                    }
                 else if (element.string)
                     element.asString
             }

--- a/jsonized/src/main/java/de/itemis/jsonized/JsonObjectEntry.xtend
+++ b/jsonized/src/main/java/de/itemis/jsonized/JsonObjectEntry.xtend
@@ -133,8 +133,14 @@ import org.eclipse.xtend.lib.annotations.Data
 			JsonPrimitive: {
 				if (v.isBoolean)
 					newTypeReference(Boolean)
-				else if (v.isNumber)
-					newTypeReference(Long)
+				else if (v.isNumber) {
+					try {
+						Long.parseLong(v.asString)
+						newTypeReference(Long)
+					} catch(NumberFormatException e) {
+						newTypeReference(Double)
+					}
+				}
 				else if (v.isString)
 					string
 			}


### PR DESCRIPTION
When interpreting numerical JSON values, jsonized assumes all Numbers to be Longs, which results in truncating any floating point values. This fix adds support for Doubles as well.  
